### PR TITLE
update project to use non-deprecated api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 fun properties(key: String) = project.findProperty(key)?.toString()
 
 plugins {
-    `kotlin-dsl`
     `maven-publish`
     signing
     kotlin("jvm") version "1.8.0"

--- a/src/main/kotlin/ski.chrzanow.transformstring/transformstring.kt
+++ b/src/main/kotlin/ski.chrzanow.transformstring/transformstring.kt
@@ -7,28 +7,28 @@ private fun String.prepare(separator: String) =
         .replace("[\\W_]".toRegex(), separator)
         .removePrefix(separator)
 
-fun String.transformstring() = prepare("").toLowerCase()
+fun String.transformstring() = prepare("").lowercase()
 
-fun String.TRANSFORMSTRING() = prepare("").toUpperCase()
+fun String.TRANSFORMSTRING() = prepare("").uppercase()
 
 fun String.transformString() = CaseUtils.toCamelCase(prepare(" "), false, ' ')
 
 fun String.TransformString() = CaseUtils.toCamelCase(prepare(" "), true, ' ')
 
-fun String.transform_string() = prepare("_").toLowerCase()
+fun String.transform_string() = prepare("_").lowercase()
 
-fun String.TRANSFORM_STRING() = prepare("_").toUpperCase()
+fun String.TRANSFORM_STRING() = prepare("_").uppercase()
 
-fun String.`transform-string`() = prepare("-").toLowerCase()
+fun String.`transform-string`() = prepare("-").lowercase()
 
-fun String.`TRANSFORM-STRING`() = prepare("-").toUpperCase()
+fun String.`TRANSFORM-STRING`() = prepare("-").uppercase()
 
 fun String.tRaNsFoRmStRiNg(): String {
     var newStr = ""
     var shouldBeUpperCase = false
     forEach { str ->
         if(str.isLetter()) {
-            newStr += if(shouldBeUpperCase) str.toUpperCase() else str.toLowerCase()
+            newStr += if(shouldBeUpperCase) str.uppercase() else str.lowercase()
             shouldBeUpperCase = !shouldBeUpperCase
         } else newStr += str
     }


### PR DESCRIPTION
kotlin-dsl isn't required here
It's good for projects that contribute build-logic, which it is not doing here. 
It also prevented the project from using non-deprecated features in text