### PR TITLE
Added JavaDoc Comment and extended Testing to the prepare function

### DIFF
--- a/src/main/kotlin/ski.chrzanow.transformstring/transformstring.kt
+++ b/src/main/kotlin/ski.chrzanow.transformstring/transformstring.kt
@@ -2,7 +2,16 @@ package ski.chrzanow.transformstring
 
 import org.apache.commons.text.CaseUtils
 
-private fun String.prepare(separator: String) =
+/**
+ * Replaces matched patterns of uppercase letters that are preceded or followed by lowercase letters with the separator
+ * followed by the matched letter. It also replaces any non-word or underscore characters with the separator. Finally,
+ * it removes any separators that may have been added to the beginning of the string.
+ *
+ *  @param separator the separator to be inserted between apparent word boundaries.
+ *  @return a string retaining its original case with each apparent word separated by the provided separator.
+ *
+ **/
+internal fun String.prepare(separator: String) =
     replace("((?<=\\p{Ll})\\p{Lu}|\\p{Lu}(?=\\p{Ll}))".toRegex(), "$separator$1")
         .replace("[\\W_]".toRegex(), separator)
         .removePrefix(separator)

--- a/src/main/kotlin/ski.chrzanow.transformstring/transformstring.kt
+++ b/src/main/kotlin/ski.chrzanow.transformstring/transformstring.kt
@@ -13,8 +13,10 @@ import org.apache.commons.text.CaseUtils
  **/
 internal fun String.prepare(separator: String) =
     replace("((?<=\\p{Ll})\\p{Lu}|\\p{Lu}(?=\\p{Ll}))".toRegex(), "$separator$1")
-        .replace("[\\W_]".toRegex(), separator)
+        .replace("[\\W_]+".toRegex(), separator)
         .removePrefix(separator)
+        .removeSuffix(separator)
+
 
 fun String.transformstring() = prepare("").toLowerCase()
 

--- a/src/test/kotlin/ski.chrzanow.transformstring/tests.kt
+++ b/src/test/kotlin/ski.chrzanow.transformstring/tests.kt
@@ -6,6 +6,30 @@ import kotlin.test.assertEquals
 class Tests {
 
     @Test
+    fun prepare() {
+        assertEquals("hello world", "hello_world".prepare(" "))
+        assertEquals("hello World", "helloWorld".prepare(" "))
+        assertEquals("HELLO WORLD", "HELLO_WORLD".prepare(" "))
+        assertEquals("hello world", "hello-world".prepare(" "))
+        assertEquals("Hello world", "Hello@world".prepare(" "))
+
+        assertEquals("Hello123world", "Hello123world".prepare(" "))
+
+        assertEquals("leading separator1", "_leading_separator1".prepare(" "))
+        assertEquals("leading_separator2", "_leading_separator2".prepare("_"))
+        assertEquals("leading separator3", "  __leading_separator3".prepare(" "))
+        assertEquals("leading_separator4", "_leading_separator4".prepare("_"))
+        assertEquals("leading@separator5", "  __leading_separator5".prepare("@"))
+
+        assertEquals("trailing@separator7", "  trailing_separator7_".prepare("@"))
+        assertEquals("trailing@separator6", "  trailing_separator6@".prepare("@"))
+        assertEquals("trailing@separator8", "  trailing_separator8@@__@".prepare("@"))
+
+        assertEquals("leadingtrailing@separator8", "__@leadingtrailing_separator8@@__@".prepare("@"))
+        assertEquals("leadingtrailing_separator8", "__@leadingtrailing_separator8@@__@".prepare("_"))
+        assertEquals("leadingtrailing separator8", "__@leadingtrailing_separator8@@__@".prepare(" "))
+    }
+    @Test
     fun lowerCase() {
         assertEquals("foobar", "foo bar".transformstring())
         assertEquals("foobar", "foo-bar".transformstring())


### PR DESCRIPTION
The prepare(...) function is relatively complex due to the use of more advanced Regex features. I used ChatGPT to summarize the function. After review, I believe the JavaDoc is mostly correct. Please verify.

I also extended the testing capabilities to cover the prepare(...) function. There were some test cases that failed, and I updated the prepare(...) function. I believe the test cases are the expected behavior.

The prepare(...) function still doesn't deal with strings of length 2 or greater, and the test result for them is a doubling of the separators; behavior that doesn't appear to be the expected behavior.